### PR TITLE
Malloc/Free Buffer Allocation Support

### DIFF
--- a/Wazzy.sln.DotSettings.user
+++ b/Wazzy.sln.DotSettings.user
@@ -1,5 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/dotCover/Editor/HighlightingSourceSnapshotLocation/@EntryValue">C:\Users\Martin\AppData\Local\Temp\JetBrains\ReSharperPlatformVs18\vAny_640a6eae\CoverageData\_Wazzy.1727317920\Snapshot\snapshot.utdcvr</s:String>
+	
 	<s:String x:Key="/Default/Environment/Highlighting/HighlightingSourceSnapshotLocation/@EntryValue">C:\Users\Martin\AppData\Local\Temp\JetBrains\ReSharperPlatformVs17\vAny_ac125f2d\CoverageData\_Wazzy.1727317920\Snapshot\snapshot.utdcvr</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0ab134e6_002Dd76d_002D43e1_002Da04d_002Da45aaa1a7b53/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="FreezeThawTests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
@@ -8,6 +8,9 @@
 &lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=333f2a06_002D5408_002D409d_002D8e8a_002D21355fc4a9db/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Solution /&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=e60ab0f2_002D1ab7_002D4b6c_002Dbcf1_002D24aca010bd6d/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;Wazzy.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Project Location="C:\Users\Martin\Documents\dotnet\Wazzy\Wazzy.Tests" Presentation="&amp;lt;Wazzy.Tests&amp;gt;" /&gt;&#xD;
 &lt;/SessionState&gt;</s:String>
 	
 	

--- a/Wazzy/Async/Extensions/CallerExtensions.cs
+++ b/Wazzy/Async/Extensions/CallerExtensions.cs
@@ -89,16 +89,19 @@ public static class CallerExtensions
     }
 
     /// <summary>
-    /// Allocate a buffer of the given size. This will only succeed if the WASM code defines a function: <code>asyncify_malloc_buffer(int size) -> int</code>
+    /// Allocate a buffer of the given size.
+    /// - If `asyncify_malloc_buffer(int32) -> int32` is defined, uses that
+    /// - If `malloc(int32) -> int32` AND `free(int32)` are defined, uses malloc
     /// </summary>
+    /// <remarks>It is allowed for `asyncify_free_buffer` to not exist, in which case freeing is a no-op</remarks>
     /// <param name="caller"></param>
     /// <param name="size"></param>
     /// <returns></returns>
     internal static int? AsyncifyMallocBuffer(this Caller caller, int size)
     {
         // Check if the special purpose malloc exists and use it
-        var async_mallocs = caller.GetAsyncifyMalloc();
-        if (async_mallocs is (var async_malloc, not null))
+        var async_malloc = caller.GetAsyncifyMalloc();
+        if (async_malloc is not null)
         {
             var ptr = async_malloc(size);
             if (ptr < 0)
@@ -121,22 +124,25 @@ public static class CallerExtensions
     }
 
     /// <summary>
-    /// Free a previously allocated buffer (with `asyncify_malloc_buffer`) at the given address
+    /// Free a previously allocated buffer
+    /// - If `asyncify_malloc_buffer(int32) -> int32` exists, use `asyncify_free_buffer(int32, int32)`
+    /// - Otherwise, if `free(int32)` exists use it
     /// </summary>
+    /// <remarks>It is allowed for `asyncify_free_buffer` to not exist, in which case freeing is a no-op</remarks>
     /// <param name="caller"></param>
     /// <param name="addr"></param>
     /// <param name="size"></param>
     internal static void AsyncifyFreeBuffer(this Caller caller, int addr, int size)
     {
         // Check if the special purpose malloc exists and use it
-        var async_mallocs = caller.GetAsyncifyMalloc();
-        if (async_mallocs is (not null, var async_free))
+        var async_malloc = caller.GetAsyncifyMalloc();
+        if (async_malloc is not null)
         {
-            async_free(addr, size);
+            caller.GetAsyncifyFree()?.Invoke(addr, size);
             return;
         }
 
-        // Try to use general purpose malloc
+        // Try to use general purpose malloc/free
         var mallocs = caller.GetMalloc();
         if (mallocs is (not null, var free))
         {
@@ -148,17 +154,23 @@ public static class CallerExtensions
     }
 
     /// <summary>
-    /// Get the special asyncify malloc functions
+    /// Get the special asyncify malloc function
     /// </summary>
     /// <param name="caller"></param>
     /// <returns></returns>
-    private static (Func<int, int> malloc, Action<int, int> free)? GetAsyncifyMalloc(this Caller caller)
+    private static Func<int, int>? GetAsyncifyMalloc(this Caller caller)
     {
-        var asyncify_malloc = caller.GetFunction("asyncify_malloc_buffer")?.WrapFunc<int, int>();
-        var asyncify_free = caller.GetFunction("asyncify_free_buffer")?.WrapAction<int, int>();
-        if (asyncify_malloc != null && asyncify_free != null)
-            return (asyncify_malloc, asyncify_free);
-        return null;
+        return caller.GetFunction("asyncify_malloc_buffer")?.WrapFunc<int, int>();
+    }
+
+    /// <summary>
+    /// Get the special asyncify free function
+    /// </summary>
+    /// <param name="caller"></param>
+    /// <returns></returns>
+    private static Action<int, int>? GetAsyncifyFree(this Caller caller)
+    {
+        return caller.GetFunction("asyncify_free_buffer")?.WrapAction<int, int>();
     }
 
     /// <summary>

--- a/Wazzy/Async/Extensions/CallerExtensions.cs
+++ b/Wazzy/Async/Extensions/CallerExtensions.cs
@@ -126,7 +126,7 @@ public static class CallerExtensions
     /// <summary>
     /// Free a previously allocated buffer
     /// - If `asyncify_malloc_buffer(int32) -> int32` exists, use `asyncify_free_buffer(int32, int32)`
-    /// - Otherwise, if `free(int32)` exists use it
+    /// - Otherwise, if `malloc(int32) -> int32` AND free(int32)` exist use `free`
     /// </summary>
     /// <remarks>It is allowed for `asyncify_free_buffer` to not exist, in which case freeing is a no-op</remarks>
     /// <param name="caller"></param>

--- a/Wazzy/Async/Extensions/CallerExtensions.cs
+++ b/Wazzy/Async/Extensions/CallerExtensions.cs
@@ -96,11 +96,28 @@ public static class CallerExtensions
     /// <returns></returns>
     internal static int? AsyncifyMallocBuffer(this Caller caller, int size)
     {
-        var ptr = caller.GetFunction("asyncify_malloc_buffer")?.WrapFunc<int, int>()?.Invoke(size) ?? -1;
-        if (ptr < 0)
-            return null;
+        // Check if the special purpose malloc exists and use it
+        var async_mallocs = caller.GetAsyncifyMalloc();
+        if (async_mallocs is (var async_malloc, not null))
+        {
+            var ptr = async_malloc(size);
+            if (ptr < 0)
+                return null;
+            return ptr;
+        }
 
-        return ptr;
+        // Try to use general purpose malloc
+        var mallocs = caller.GetMalloc();
+        if (mallocs is (var malloc, not null))
+        {
+            var ptr = malloc(size);
+            if (ptr <= 0)
+                return null;
+            return ptr;
+        }
+
+        // No malloc available
+        return null;
     }
 
     /// <summary>
@@ -111,6 +128,50 @@ public static class CallerExtensions
     /// <param name="size"></param>
     internal static void AsyncifyFreeBuffer(this Caller caller, int addr, int size)
     {
-        caller.GetFunction("asyncify_free_buffer")?.WrapAction<int, int>()?.Invoke(addr, size);
+        // Check if the special purpose malloc exists and use it
+        var async_mallocs = caller.GetAsyncifyMalloc();
+        if (async_mallocs is (not null, var async_free))
+        {
+            async_free(addr, size);
+            return;
+        }
+
+        // Try to use general purpose malloc
+        var mallocs = caller.GetMalloc();
+        if (mallocs is (not null, var free))
+        {
+            free(addr);
+            return;
+        }
+
+        // No malloc available
+    }
+
+    /// <summary>
+    /// Get the special asyncify malloc functions
+    /// </summary>
+    /// <param name="caller"></param>
+    /// <returns></returns>
+    private static (Func<int, int> malloc, Action<int, int> free)? GetAsyncifyMalloc(this Caller caller)
+    {
+        var asyncify_malloc = caller.GetFunction("asyncify_malloc_buffer")?.WrapFunc<int, int>();
+        var asyncify_free = caller.GetFunction("asyncify_free_buffer")?.WrapAction<int, int>();
+        if (asyncify_malloc != null && asyncify_free != null)
+            return (asyncify_malloc, asyncify_free);
+        return null;
+    }
+
+    /// <summary>
+    /// Get the general malloc functions
+    /// </summary>
+    /// <param name="caller"></param>
+    /// <returns></returns>
+    private static (Func<int, int> malloc, Action<int> free)? GetMalloc(this Caller caller)
+    {
+        var malloc = caller.GetFunction("malloc")?.WrapFunc<int, int>();
+        var free = caller.GetFunction("free")?.WrapAction<int>();
+        if (malloc != null && free != null)
+            return (malloc, free);
+        return null;
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -41,14 +41,20 @@ wasm-opt module.wasm -o module-async.wasm --asyncify
 
 ### Cooperative Allocation
 
-Asyncify the module the same way as before.
+Compile your module and export `malloc` and `free` functions. Asyncify in the same way as before.
 
-Export a two methods for cooperative allocation: `asyncify_malloc_buffer(int32) -> int32` & `asyncify_free_buffer(int32, int32)`.
+Wazzy will use malloc and free to allocate memory buffers for itself, which makes async unwind/rewind more efficient.
 
- - `asyncify_malloc_buffer` should accept a size and should return a pointer to a buffer of that size (or a negative number, to indicate allocation failure).
- - `asyncify_free_buffer` should accept a pointer to a buffer and the size of that buffer (both matching a previous `asyncify_malloc_buffer` call) and free it.
+### Cooperative Allocation (Special)
 
-Wazzy will use these methods to allocate memory for itself, which makes async unwind/rewind more efficient.
+If you want to provide a special purpose allocator specifically for async unwind/rewind (e.g. returning a pointer to a statically allocated buffer), export:
+
+ - `asyncify_malloc_buffer(int32 size) -> int32 address`
+ - `asyncify_free_buffer(int32 address, int32 size)`
+
+If `asyncify_malloc_buffer` is defined it will be used instead of `malloc`/`free` even if they are exported.
+
+`asyncify_free_buffer` is optional, if it is not defined free becomes a no-op.
 
 ### Multi Memory
 

--- a/readme.md
+++ b/readme.md
@@ -64,4 +64,4 @@ Export a second memory named `asyncify_unwind_stack_memory_heap` and asyncify us
 wasm-opt module.wasm -o module-async.wasm --asyncify --enable-multimemory --pass-arg=asyncify-memory@asyncify_unwind_stack_memory_heap
 ```
 
-Wazzy/Asyncify will use this second memory for all unwind/rewind operations, which is more efficient.
+Wazzy/Asyncify will use this second memory for all unwind/rewind operations, which is more efficient. If this second memory exists the cooperative allocation functions are ignored.


### PR DESCRIPTION
Added support for using normal malloc/free if it is exported.

If the special `asyncify_malloc_buffer`/`asyncify_free_buffer` pair of functions are defined, they will be used instead of malloc/free.